### PR TITLE
streamline IRC hot paths

### DIFF
--- a/src/circed/actions/kick.cr
+++ b/src/circed/actions/kick.cr
@@ -29,7 +29,7 @@ module Circed
     end
 
     private def self.split_list_param(param : String) : Array(String)
-      param.split(',').reject(&.empty?)
+      param.split(',', remove_empty: true)
     end
   end
 end

--- a/src/circed/actions/names.cr
+++ b/src/circed/actions/names.cr
@@ -41,7 +41,7 @@ module Circed
     end
 
     private def self.split_list_param(param : String) : Array(String)
-      param.split(',').reject(&.empty?)
+      param.split(',', remove_empty: true)
     end
 
     private def self.can_see_channel?(sender : Client, channel : Domain::Channel) : Bool

--- a/src/circed/actions/who.cr
+++ b/src/circed/actions/who.cr
@@ -37,8 +37,7 @@ module Circed
       # Send WHO replies for each member
       channel.members.each do |nickname, modes|
         if client = user_repo.get_client(nickname)
-          mode_strings = modes.map(&.to_s)
-          send_who_reply(sender, client, channel, mode_strings)
+          send_who_reply(sender, client, channel, modes)
         end
       end
 
@@ -51,9 +50,8 @@ module Circed
       if client = user_repo.get_client(target)
         # Find a common channel or just send basic info
         channel = find_common_channel(sender, client)
-        modes = [] of String
 
-        send_who_reply(sender, client, channel, modes)
+        send_who_reply(sender, client, channel)
       end
 
       send_end_of_who(sender, target)
@@ -91,25 +89,12 @@ module Circed
       nil
     end
 
-    private def self.send_who_reply(sender : Client, client : Client, channel : Domain::Channel? = nil, modes : Array(String) = [] of String)
+    private def self.send_who_reply(sender : Client, client : Client, channel : Domain::Channel? = nil, modes : Set(Char)? = nil)
       # WHO reply format:
       # :server 352 nick channel username host server nick flags :hopcount realname
 
       user = client.user
       return unless user
-
-      # Build flags
-      flags = "H"                                        # Here (not away)
-      flags += "*" if client.nickname == sender.nickname # Self
-
-      # Add channel operator status if in a channel
-      if channel
-        if modes.includes?("o")
-          flags += "@"
-        elsif modes.includes?("v")
-          flags += "+"
-        end
-      end
 
       # Channel name or "*" if no channel
       channel_name = channel ? channel.name : "*"
@@ -126,9 +111,25 @@ module Circed
         hostname,
         Server.clean_name,
         client.nickname || "*",
-        flags,
+        who_flags(sender, client, channel, modes),
         ":0 #{user.realname}"
       )
+    end
+
+    private def self.who_flags(sender : Client, client : Client, channel : Domain::Channel?, modes : Set(Char)?) : String
+      flags = "H"
+      flags += "*" if client.nickname == sender.nickname
+      if channel && (prefix = channel_mode_prefix(modes))
+        flags += prefix.to_s
+      end
+      flags
+    end
+
+    private def self.channel_mode_prefix(modes : Set(Char)?) : Char?
+      return nil unless modes
+
+      return '@' if modes.includes?('o')
+      return '+' if modes.includes?('v')
     end
 
     private def self.send_end_of_who(sender : Client, target : String)

--- a/src/circed/clients/client.cr
+++ b/src/circed/clients/client.cr
@@ -475,7 +475,7 @@ module Circed
     private def split_list_param(param : String?) : Array(String)
       return [] of String unless param
 
-      param.split(',').reject(&.empty?)
+      param.split(',', remove_empty: true)
     end
 
     private def get_hostname : String?

--- a/src/circed/mixins/unified_messaging.cr
+++ b/src/circed/mixins/unified_messaging.cr
@@ -64,7 +64,7 @@ module Circed
       # Collect unique users from these channels
       unique_users = Set(String).new
       user_channels.each do |channel|
-        channel.members.keys.each { |nickname| unique_users << nickname }
+        channel.members.each_key { |nickname| unique_users << nickname }
       end
 
       # Send to each unique user
@@ -175,7 +175,7 @@ module Circed
       unique_users = Set(String).new
 
       user_channels.each do |channel|
-        channel.members.keys.each { |nickname| unique_users << nickname }
+        channel.members.each_key { |nickname| unique_users << nickname }
       end
 
       unique_users.each do |nickname|

--- a/src/circed/network/connection_pool.cr
+++ b/src/circed/network/connection_pool.cr
@@ -11,7 +11,7 @@ module Circed
       CLEANUP_INTERVAL = 5.minutes
 
       # Connection state tracking
-      private struct ConnectionInfo
+      private class ConnectionInfo
         getter server : LinkServer
         getter last_activity : Time
         getter? idle : Bool

--- a/src/circed/repositories/channel_repository.cr
+++ b/src/circed/repositories/channel_repository.cr
@@ -153,7 +153,7 @@ module Circed
 
       def find_channels_with_local_users(user_repository : UserRepository) : Array(Domain::Channel)
         @@channels.values.select do |channel|
-          channel.members.keys.any? { |nick| user_repository.has_client?(nick) }
+          channel.members.each_key.any? { |nick| user_repository.has_client?(nick) }
         end
       end
 

--- a/src/circed/repositories/server_repository.cr
+++ b/src/circed/repositories/server_repository.cr
@@ -96,7 +96,7 @@ module Circed
 
         disconnected = [] of String
 
-        @@servers.keys.each do |server_name|
+        @@servers.each_key do |server_name|
           next if server_name == from || server_name == split_server
 
           unless can_reach_without(server_name, split_server, from, Set(String).new)

--- a/src/circed/server.cr
+++ b/src/circed/server.cr
@@ -380,10 +380,6 @@ module Circed
       client.send_message(Server.clean_name, Numerics::RPL_YOURHOST, client.nickname, ":Your host is #{Server.config.host}, running version #{VERSION}")
       client.send_message(Server.clean_name, Numerics::RPL_CREATED, client.nickname, ":This server was created on #{Server.start_time}")
       client.send_message(Server.clean_name, Numerics::RPL_MYINFO, client.nickname, "#{Server.config.host} #{VERSION} oiwszcrkfydnxbauglZCD biklmnopstvrDdRcC bkloveqjfI")
-
-      # Sync new user with network state
-      irc_service = Infrastructure::ServiceLocator.irc_service
-      irc_service.sync_new_user(client)
     end
 
     def self.lusers(client : Client)

--- a/src/circed/servers/link_server.cr
+++ b/src/circed/servers/link_server.cr
@@ -325,7 +325,7 @@ module Circed
         Network::NetworkState.add_user(new_nick, user.username, user.hostname, user.realname, user.server, user.hopcount)
 
         # Update channel memberships
-        Network::NetworkState.channels.each do |_, channel|
+        Network::NetworkState.channels.each_value do |channel|
           if channel.members.has_key?(old_nick)
             modes = channel.members.delete(old_nick)
             channel.members[new_nick] = modes if modes
@@ -666,18 +666,12 @@ module Circed
 
     private def deliver_to_local_channel(channel_name : String, payload, sender_nick : String, message : String)
       if channel = Network::NetworkState.get_channel(channel_name)
-        # Find local users in this channel
         user_repository = Infrastructure::ServiceLocator.user_repository
-        local_users = channel.members.keys.select do |nick|
-          user_repository.get_client(nick)
-        end
 
-        # Send message to each local user
-        local_users.each do |local_nick|
+        channel.members.each_key do |local_nick|
+          next if local_nick == sender_nick
+
           if client = user_repository.get_client(local_nick)
-            # Don't send message back to the sender if they're local
-            next if local_nick == sender_nick
-
             formatted_message = format_message_for_client(payload, message)
             client.send_message(formatted_message)
           end
@@ -806,11 +800,7 @@ module Circed
     private def send_to_local_channel_members(channel_name : String, message : String, exclude_nick : String? = nil)
       if channel = Network::NetworkState.get_channel(channel_name)
         user_repository = Infrastructure::ServiceLocator.user_repository
-        local_users = channel.members.keys.select do |nick|
-          user_repository.get_client(nick)
-        end
-
-        local_users.each do |local_nick|
+        channel.members.each_key do |local_nick|
           next if exclude_nick && local_nick == exclude_nick
 
           if client = user_repository.get_client(local_nick)
@@ -821,16 +811,13 @@ module Circed
     end
 
     private def send_quit_to_shared_local_users(remote_nick : String, message : String)
-      # Find all channels the remote user was in
-      affected_channels = Network::NetworkState.channels.select do |_, channel|
-        channel.members.has_key?(remote_nick)
-      end
-
       # Collect all local users who shared channels (avoid duplicates)
       user_repository = Infrastructure::ServiceLocator.user_repository
       local_users = Set(String).new
-      affected_channels.each do |_, channel|
-        channel.members.keys.each do |nick|
+      Network::NetworkState.channels.each_value do |channel|
+        next unless channel.members.has_key?(remote_nick)
+
+        channel.members.each_key do |nick|
           local_users << nick if user_repository.get_client(nick)
         end
       end
@@ -845,14 +832,12 @@ module Circed
 
     private def send_nick_to_shared_local_users(old_nick : String, message : String)
       # Similar to QUIT - find all local users who shared channels
-      affected_channels = Network::NetworkState.channels.select do |_, channel|
-        channel.members.has_key?(old_nick)
-      end
-
       user_repository = Infrastructure::ServiceLocator.user_repository
       local_users = Set(String).new
-      affected_channels.each do |_, channel|
-        channel.members.keys.each do |nick|
+      Network::NetworkState.channels.each_value do |channel|
+        next unless channel.members.has_key?(old_nick)
+
+        channel.members.each_key do |nick|
           local_users << nick if user_repository.get_client(nick)
         end
       end

--- a/src/circed/services/irc_service.cr
+++ b/src/circed/services/irc_service.cr
@@ -58,12 +58,14 @@ module Circed
         # Sync with network state
         sync_join_with_network(nickname, channel_name)
 
+        hostmask = client.hostmask || ""
+
         # Send JOIN confirmation to the user (first message)
-        client.send_message(":#{client.hostmask} JOIN #{channel_name}")
+        client.send_message(":#{hostmask} JOIN #{channel_name}")
 
         # Send MODE message if user became operator (second message)
         if is_operator
-          client.send_message(":#{client.hostmask} MODE #{channel_name} +o #{nickname}")
+          client.send_message(":#{hostmask} MODE #{channel_name} +o #{nickname}")
         end
 
         # Send topic if channel has one
@@ -78,10 +80,10 @@ module Circed
         send_names_list(client, channel)
 
         # Send notifications to other users
-        @notification_service.notify_user_joined(nickname, channel_name)
+        @notification_service.notify_user_joined(hostmask, channel, nickname)
 
         # Propagate to network
-        propagate_to_network(":#{client.hostmask} JOIN #{channel_name}")
+        propagate_to_network(":#{hostmask} JOIN #{channel_name}")
 
         true
       end

--- a/src/circed/services/notification_service.cr
+++ b/src/circed/services/notification_service.cr
@@ -22,6 +22,11 @@ module Circed
         end
       end
 
+      def notify_user_joined(hostmask : String, channel : Domain::Channel, exclude_nickname : String)
+        message = ":#{hostmask} JOIN #{channel.name}"
+        send_to_channel_members(channel, message, exclude_nickname)
+      end
+
       def notify_user_parted(nickname : String, channel_name : String, reason : String? = nil)
         if user = @user_repository.get(nickname)
           message = String.build do |io|
@@ -199,12 +204,16 @@ module Circed
 
       private def send_to_channel_members(channel_name : String, message : String, exclude_nickname : String? = nil)
         if channel = @channel_repository.get(channel_name)
-          channel.members.each_key do |nickname|
-            next if exclude_nickname && nickname == exclude_nickname
+          send_to_channel_members(channel, message, exclude_nickname)
+        end
+      end
 
-            if client = @user_repository.get_client(nickname)
-              client.send_message(message)
-            end
+      private def send_to_channel_members(channel : Domain::Channel, message : String, exclude_nickname : String? = nil)
+        channel.members.each_key do |nickname|
+          next if exclude_nickname && nickname == exclude_nickname
+
+          if client = @user_repository.get_client(nickname)
+            client.send_message(message)
           end
         end
       end

--- a/src/circed/services/rate_limiter.cr
+++ b/src/circed/services/rate_limiter.cr
@@ -3,9 +3,11 @@ module Circed
     # Rate limiter for IRC commands to prevent flooding
     class RateLimiter
       # Per-client rate limiting configuration
-      DEFAULT_MAX_COMMANDS = 10
-      DEFAULT_TIME_WINDOW  = 60 # seconds
-      DEFAULT_BURST_SIZE   =  5
+      DEFAULT_MAX_COMMANDS  = 10
+      DEFAULT_TIME_WINDOW   = 60 # seconds
+      DEFAULT_BURST_SIZE    =  5
+      REGISTRATION_COMMANDS = {"NICK", "USER", "PASS", "SERVER"}
+      UNLIMITED_COMMANDS    = {"PING", "PONG", "ERROR", "QUIT"}
 
       # Different rate limits for different command types
       COMMAND_LIMITS = {
@@ -146,12 +148,12 @@ module Circed
 
       # Special handling for burst commands during registration
       def self.registration_command?(command : String) : Bool
-        ["NICK", "USER", "PASS", "SERVER"].includes?(command)
+        REGISTRATION_COMMANDS.includes?(command)
       end
 
       def self.should_rate_limit?(command : String) : Bool
         # Don't rate limit certain system commands
-        !["PING", "PONG", "ERROR", "QUIT"].includes?(command)
+        !UNLIMITED_COMMANDS.includes?(command)
       end
     end
   end


### PR DESCRIPTION
This streamlines a few IRC hot paths without carrying the more verbose manual array-building optimizations. It removes duplicate user sync during registration, avoids extra JOIN notification lookups, uses direct key/value iteration where it naturally avoids temporary collections, and keeps the rest of the code in the clearer existing style.

Checks run:
- `bin/ameba`
- `crystal spec spec/circed`
- `crystal spec spec/integration`
- `git diff --check`