### PR TITLE
add IRC operator command support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ A Crystal IRC server implementation that follows IRC protocol specifications. Wh
     joined channel, and hostmask plus realname masks
 * User information lookup (IP, hostname, WHOIS)
 * Activity and signon time tracking
+* IRC operator authentication with `OPER`
+* Oper-only administrative commands: `KILL`, `REHASH`, `CONNECT`, `SQUIT`,
+  `DIE`, `RESTART`, and `WALLOPS`
 
 ### Network & Security
 * **SSL/TLS Support** - Secure connections for clients and servers
@@ -29,7 +32,6 @@ A Crystal IRC server implementation that follows IRC protocol specifications. Wh
 * Additional channel and user modes
 
 ### Not Implemented
-* IRC operator authentication and oper-only commands
 * Network-wide GLines
 * NickServ, ChanServ, and persistent IRC services
 
@@ -53,7 +55,43 @@ port: 6667
 network: "MyIRCNetwork"
 max_users: 100
 link_password: "server_link_password"
+allow_die: false
+allow_restart: false
 ```
+
+### IRC Operators
+
+IRC operators are configured with O-line style entries under `operators`.
+Clients authenticate with `OPER <name> <password>`. On success, CrIRCd sends
+`381 RPL_YOUREOPER` and sets user mode `+o` for global operators or `+O` for
+local operators. Users cannot grant themselves `+o` or `+O` with `MODE`; those
+modes must come from `OPER`, though users may remove their own operator mode.
+Operators can use `KILL <nickname> :<reason>` to disconnect users, `REHASH` to
+reload config, `CONNECT` to start a configured server link, and `SQUIT` to drop
+a server link. They can also use `WALLOPS :<message>` to send a server notice to
+local users with mode `+w`. `DIE` and `RESTART` are disabled by default and
+require `allow_die: true` or `allow_restart: true`.
+
+```yaml
+operators:
+  - name: "admin"
+    password: "change-this-password"
+    hosts:
+      - "*!admin@trusted.example.com"
+      - "trusted.example.com"
+
+  - name: "local-admin"
+    password: "change-this-too"
+    local: true
+    hosts:
+      - "localhost"
+      - "*!oper@127.0.0.1"
+```
+
+`hosts` is optional and defaults to `["*"]`. Host masks are matched
+case-insensitively with `*` and `?` wildcards against the user's hostmask,
+resolved hostname, and socket host string. Prefer restrictive host masks in
+production.
 
 ## Testing
 
@@ -155,13 +193,14 @@ CrIRCd currently supports these client-facing commands:
 * Messaging: `PRIVMSG`, `NOTICE`
 * Channels: `JOIN`, `PART`, `MODE`, `TOPIC`, `INVITE`, `KICK`, `NAMES`, `LIST`,
   `WHO`
+* Operator commands: `OPER`, `KILL`, `REHASH`, `CONNECT`, `SQUIT`, `DIE`,
+  `RESTART`, `WALLOPS`
 * User/server queries: `WHOIS`, `LINKS`, `STATS`, `TIME`, `VERSION`, `ADMIN`
 
 Server-to-server links support handshake, burst, channel membership, user state,
 message routing, and basic server query propagation.
 
-Unsupported areas include IRC operator authentication, network GLines, and
-persistent IRC services.
+Unsupported areas include network GLines and persistent IRC services.
 
 ## Configuration Reload
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A Crystal IRC server implementation that follows IRC protocol specifications. Wh
 * Activity and signon time tracking
 * IRC operator authentication with `OPER`
 * Oper-only administrative commands: `KILL`, `REHASH`, `CONNECT`, `SQUIT`,
-  `DIE`, `RESTART`, and `WALLOPS`
+  `DIE`, and `RESTART`
 
 ### Network & Security
 * **SSL/TLS Support** - Secure connections for clients and servers
@@ -68,9 +68,12 @@ local operators. Users cannot grant themselves `+o` or `+O` with `MODE`; those
 modes must come from `OPER`, though users may remove their own operator mode.
 Operators can use `KILL <nickname> :<reason>` to disconnect users, `REHASH` to
 reload config, `CONNECT` to start a configured server link, and `SQUIT` to drop
-a server link. They can also use `WALLOPS :<message>` to send a server notice to
-local users with mode `+w`. `DIE` and `RESTART` are disabled by default and
-require `allow_die: true` or `allow_restart: true`.
+a server link. `DIE` and `RESTART` are disabled by default and require
+`allow_die: true` or `allow_restart: true`.
+
+Users can set `MODE <nick> +w` to receive wallops notices from linked servers.
+CrIRCd treats `WALLOPS` as a server-originated command and does not expose it as
+a client operator command.
 
 ```yaml
 operators:
@@ -194,7 +197,7 @@ CrIRCd currently supports these client-facing commands:
 * Channels: `JOIN`, `PART`, `MODE`, `TOPIC`, `INVITE`, `KICK`, `NAMES`, `LIST`,
   `WHO`
 * Operator commands: `OPER`, `KILL`, `REHASH`, `CONNECT`, `SQUIT`, `DIE`,
-  `RESTART`, `WALLOPS`
+  `RESTART`
 * User/server queries: `WHOIS`, `LINKS`, `STATS`, `TIME`, `VERSION`, `ADMIN`
 
 Server-to-server links support handshake, burst, channel membership, user state,

--- a/spec/circed/actions/whois_spec.cr
+++ b/spec/circed/actions/whois_spec.cr
@@ -1,0 +1,40 @@
+require "../../spec_helper"
+
+describe Circed::Actions::Whois do
+  before_each do
+    clear_repositories
+  end
+
+  after_each do
+    clear_repositories
+  end
+
+  it "reports global operator status" do
+    sender = create_test_client("Alice")
+    create_test_client("Bob")
+    user_repository.get("Bob").try { |user| user.modes << 'o' }
+
+    Circed::Actions::Whois.call(sender, "Bob")
+
+    sender.socket.as(DummySocket).sent_data.join.should contain(" 313 Alice Bob :is an IRC operator")
+  end
+
+  it "reports local operator status" do
+    sender = create_test_client("Alice")
+    create_test_client("Bob")
+    user_repository.get("Bob").try { |user| user.modes << 'O' }
+
+    Circed::Actions::Whois.call(sender, "Bob")
+
+    sender.socket.as(DummySocket).sent_data.join.should contain(" 313 Alice Bob :is an IRC operator")
+  end
+
+  it "does not report operator status for normal users" do
+    sender = create_test_client("Alice")
+    create_test_client("Bob")
+
+    Circed::Actions::Whois.call(sender, "Bob")
+
+    sender.socket.as(DummySocket).sent_data.join.should_not contain(" 313 Alice Bob")
+  end
+end

--- a/spec/circed/clients/client_registration_spec.cr
+++ b/spec/circed/clients/client_registration_spec.cr
@@ -41,6 +41,19 @@ describe Circed::Client do
     client.hostmask.should eq("Alice!alice@localhost")
   end
 
+  it "applies RFC USER mode bits during registration" do
+    socket = DummySocket.new
+    client = Circed::Client.new(socket.as(Circed::Network::SSLSocket::IRCSocket), [] of String)
+
+    Circed::Actions::Nick.call(client, "Alice")
+    client.user = ["alice", "12", "*", ":Alice Example"]
+
+    user = user_repository.get("Alice")
+    user.should_not be_nil
+    user.try(&.modes.includes?('w')).should be_true
+    user.try(&.modes.includes?('i')).should be_true
+  end
+
   it "batches queued client messages into a single socket write" do
     with_real_outbound_writer do
       socket = DummySocket.new

--- a/spec/circed/commands/server_commands_spec.cr
+++ b/spec/circed/commands/server_commands_spec.cr
@@ -91,6 +91,26 @@ describe Circed::Commands::ServerCommands do
     end
   end
 
+  describe "WALLOPS command" do
+    it "forwards server wallops to local users with +w mode" do
+      link_server = create_link_server
+      wallops_user = create_test_client("Alice")
+      quiet_user = create_test_client("Bob")
+      user_repository.get("Alice").try { |user| user.modes << 'w' }
+
+      Circed::Commands::ServerCommands.wallops(link_server, [":Network maintenance"])
+
+      wallops_user.socket.as(DummySocket).sent_data.join.should contain("WALLOPS :Network maintenance")
+      quiet_user.socket.as(DummySocket).sent_data.join.should_not contain("WALLOPS")
+    end
+
+    it "handles empty WALLOPS parameters gracefully" do
+      link_server = create_link_server
+
+      Circed::Commands::ServerCommands.wallops(link_server, [] of String)
+    end
+  end
+
   describe "NJOIN command" do
     it "joins multiple users to channel efficiently" do
       link_server = create_link_server

--- a/spec/circed/server_spec.cr
+++ b/spec/circed/server_spec.cr
@@ -1,5 +1,15 @@
+require "../spec_helper"
+
 describe Circed::Server do
   # Tests for server functionality
+
+  before_each do
+    clear_repositories
+  end
+
+  after_each do
+    clear_repositories
+  end
 
   it "should return name" do
     Circed::Server.name.should eq("localhost")
@@ -11,5 +21,25 @@ describe Circed::Server do
 
   it "should return clean_name with :" do
     Circed::Server.clean_name.should eq(":localhost")
+  end
+
+  it "advertises implemented user and channel modes in MYINFO" do
+    client = create_test_client("Alice")
+
+    Circed::Server.welcome_message(client)
+
+    client.socket.as(DummySocket).sent_data.join.should contain(" 004 Alice localhost ")
+    client.socket.as(DummySocket).sent_data.join.should contain(" iwoO biklmnopsthv")
+  end
+
+  it "reports the current IRC operator count in LUSERS" do
+    alice = create_test_client("Alice")
+    create_test_client("Bob")
+    user_repository.get("Alice").try { |user| user.modes << 'o' }
+    user_repository.get("Bob").try { |user| user.modes << 'i' }
+
+    response = Circed::Server.lusers(alice)
+    response.should contain(" 251 Alice :There are 1 users and 1 invisible on 1 server(s)")
+    response.should contain(" 252 Alice :1 IRC Operators online")
   end
 end

--- a/spec/circed/servers/link_server_spec.cr
+++ b/spec/circed/servers/link_server_spec.cr
@@ -200,6 +200,27 @@ describe Circed::LinkServer do
         ex.message.should_not be_nil
       end
     end
+
+    it "handles user MODE replacements" do
+      link_server = Circed::LinkServer.allocate
+      Circed::Network::NetworkState.add_user("testnick", "testuser", "test.host.com", "Test User", "remote.server.com", 1)
+      user = Circed::Network::NetworkState.get_user("testnick")
+      user.should_not be_nil
+      user.try(&.modes.<<('o'))
+
+      payload = FastIRC::Message.new(
+        "MODE",
+        ["testnick", "-o+O"],
+        prefix: FastIRC::Prefix.new(source: "remote.server.com", user: nil, host: nil)
+      )
+
+      link_server.handle_mode_message(payload)
+
+      modes = Circed::Network::NetworkState.get_user("testnick").try(&.modes)
+      modes.should_not be_nil
+      modes.try(&.includes?('O')).should be_true
+      modes.try(&.includes?('o')).should be_false
+    end
   end
 
   describe "error handling" do

--- a/spec/circed/services/operator_spec.cr
+++ b/spec/circed/services/operator_spec.cr
@@ -1,0 +1,178 @@
+require "../../spec_helper"
+
+def operator_test_config : Circed::Config
+  Circed::Config.from_yaml(<<-YAML)
+    host: "localhost"
+    port: 6667
+    max_users: 1000
+    server_password: nil
+    network: "TestNet"
+    link_password: "password"
+    operators:
+      - name: "global"
+        password: "secret"
+        hosts:
+          - "*!test@localhost"
+      - name: "local"
+        password: "local-secret"
+        local: true
+        hosts:
+          - "localhost"
+      - name: "remote"
+        password: "remote-secret"
+        hosts:
+          - "*.example.com"
+    YAML
+end
+
+describe "IRC operator support" do
+  original_config = Circed::Server.config
+
+  before_each do
+    clear_repositories
+    Circed::Server.config = operator_test_config
+  end
+
+  after_each do
+    clear_repositories
+    Circed::Server.config = original_config
+  end
+
+  it "grants global operator privileges with OPER" do
+    client = create_test_client("Alice")
+
+    Circed::Infrastructure::ServiceLocator.irc_service.oper(client, "global", "secret")
+
+    user = user_repository.get("Alice")
+    user.should_not be_nil
+    user.try(&.modes.includes?('o')).should be_true
+    user.try(&.modes.includes?('O')).should be_false
+
+    sent = client.socket.as(DummySocket).sent_data.join
+    sent.should contain(" 381 Alice :You are now an IRC operator")
+    sent.should contain(" MODE Alice +o")
+  end
+
+  it "grants local operator privileges with OPER" do
+    client = create_test_client("Alice")
+
+    Circed::Infrastructure::ServiceLocator.irc_service.oper(client, "local", "local-secret")
+
+    user = user_repository.get("Alice")
+    user.should_not be_nil
+    user.try(&.modes.includes?('O')).should be_true
+    user.try(&.modes.includes?('o')).should be_false
+
+    client.socket.as(DummySocket).sent_data.join.should contain(" MODE Alice +O")
+  end
+
+  it "rejects bad operator passwords" do
+    client = create_test_client("Alice")
+
+    Circed::Infrastructure::ServiceLocator.irc_service.oper(client, "global", "wrong")
+
+    user_repository.get("Alice").try(&.modes.includes?('o')).should be_false
+    client.socket.as(DummySocket).sent_data.join.should contain(" 464 Alice :Password incorrect")
+  end
+
+  it "rejects operator requests from disallowed hosts" do
+    client = create_test_client("Alice")
+
+    Circed::Infrastructure::ServiceLocator.irc_service.oper(client, "remote", "remote-secret")
+
+    user_repository.get("Alice").try(&.modes.includes?('o')).should be_false
+    client.socket.as(DummySocket).sent_data.join.should contain(" 491 Alice :No O-lines for your host")
+  end
+
+  it "ignores direct attempts to self-grant operator mode" do
+    client = create_test_client("Alice")
+
+    Circed::Actions::Mode.call(client, ["Alice", "+o"])
+
+    user_repository.get("Alice").try(&.modes.includes?('o')).should be_false
+  end
+
+  it "allows IRC operators to kill local users" do
+    oper = create_test_client("Alice")
+    victim = create_test_client("Bob")
+    user_repository.get("Alice").try { |user| user.modes << 'o' }
+
+    Circed::Infrastructure::ServiceLocator.irc_service.kill_user(oper, "Bob", "Testing")
+
+    user_repository.get("Bob").should be_nil
+    victim.socket.as(DummySocket).sent_data.join.should contain("ERROR :Killed by Alice: Testing")
+  end
+
+  it "rejects KILL from non-operators" do
+    client = create_test_client("Alice")
+    create_test_client("Bob")
+
+    Circed::Infrastructure::ServiceLocator.irc_service.kill_user(client, "Bob", "Testing")
+
+    user_repository.get("Bob").should_not be_nil
+    client.socket.as(DummySocket).sent_data.join.should contain(" 481 Alice :Permission Denied- You're not an IRC operator")
+  end
+
+  it "rejects KILL targeting servers" do
+    oper = create_test_client("Alice")
+    user_repository.get("Alice").try { |user| user.modes << 'o' }
+
+    Circed::Infrastructure::ServiceLocator.irc_service.kill_user(oper, "irc.example.com", "Testing")
+
+    oper.socket.as(DummySocket).sent_data.join.should contain(" 483 Alice irc.example.com :You can't kill a server!")
+  end
+
+  it "requires operator privileges for administrative commands" do
+    client = create_test_client("Alice")
+    service = Circed::Infrastructure::ServiceLocator.irc_service
+
+    service.rehash(client)
+    service.connect_server(client, "irc.example.com")
+    service.squit_server(client, "irc.example.com", "Testing")
+    service.die(client, "Testing")
+    service.restart(client, "Testing")
+    service.wallops(client, "Testing")
+
+    sent = client.socket.as(DummySocket).sent_data.join
+    sent.scan(/ 481 Alice /).size.should eq(6)
+  end
+
+  it "keeps DIE and RESTART disabled unless explicitly configured" do
+    oper = create_test_client("Alice")
+    user_repository.get("Alice").try { |user| user.modes << 'o' }
+    service = Circed::Infrastructure::ServiceLocator.irc_service
+
+    service.die(oper, "Testing")
+    service.restart(oper, "Testing")
+
+    sent = oper.socket.as(DummySocket).sent_data.join
+    sent.should contain(" 481 Alice :DIE is disabled in server configuration")
+    sent.should contain(" 481 Alice :RESTART is disabled in server configuration")
+  end
+
+  it "returns server errors for CONNECT and SQUIT targets it cannot resolve" do
+    oper = create_test_client("Alice")
+    user_repository.get("Alice").try { |user| user.modes << 'o' }
+    service = Circed::Infrastructure::ServiceLocator.irc_service
+
+    service.connect_server(oper, "irc.example.com")
+    service.squit_server(oper, "irc.example.com", "Testing")
+
+    sent = oper.socket.as(DummySocket).sent_data.join
+    sent.should contain(" 263 Alice CONNECT :Please wait a while and try again.")
+    sent.should contain(" 402 Alice irc.example.com :No such server")
+  end
+
+  it "sends WALLOPS from operators to local wallops users" do
+    oper = create_test_client("Alice")
+    wallops_user = create_test_client("Bob")
+    quiet_user = create_test_client("Carol")
+    user_repository.get("Alice").try { |user| user.modes << 'o' }
+    user_repository.get("Bob").try { |user| user.modes << 'w' }
+
+    Circed::Infrastructure::ServiceLocator.irc_service.wallops(oper, "Server notice")
+
+    wallops_user.socket.as(DummySocket).sent_data.join.should contain(":localhost WALLOPS :Server notice")
+    quiet_user.socket.as(DummySocket).sent_data.join.should_not contain("WALLOPS")
+  end
+end

--- a/spec/circed/services/operator_spec.cr
+++ b/spec/circed/services/operator_spec.cr
@@ -25,16 +25,41 @@ def operator_test_config : Circed::Config
     YAML
 end
 
+class RecordingLinkServer < Circed::LinkServer
+  getter sent_messages = [] of String
+
+  def initialize(@name : String, target_host : String? = nil, @target_port : Int32 = 6667)
+    @target_host = target_host || @name
+  end
+
+  def safe_send(message : String) : Bool
+    @sent_messages << message
+    true
+  end
+
+  def close(reason : String = "Closing connection")
+    @sent_messages << "CLOSE #{reason}"
+  end
+
+  def closed? : Bool
+    false
+  end
+end
+
 describe "IRC operator support" do
   original_config = Circed::Server.config
 
   before_each do
     clear_repositories
+    Circed::Network::NetworkState.clear_all_state
+    Circed::ServerHandler.servers.clear
     Circed::Server.config = operator_test_config
   end
 
   after_each do
     clear_repositories
+    Circed::Network::NetworkState.clear_all_state
+    Circed::ServerHandler.servers.clear
     Circed::Server.config = original_config
   end
 
@@ -173,10 +198,9 @@ describe "IRC operator support" do
     service.squit_server(client, "irc.example.com", "Testing")
     service.die(client, "Testing")
     service.restart(client, "Testing")
-    service.wallops(client, "Testing")
 
     sent = client.socket.as(DummySocket).sent_data.join
-    sent.scan(/ 481 Alice /).size.should eq(6)
+    sent.scan(/ 481 Alice /).size.should eq(5)
   end
 
   it "keeps DIE and RESTART disabled unless explicitly configured" do
@@ -214,27 +238,34 @@ describe "IRC operator support" do
     oper.socket.as(DummySocket).sent_data.join.should contain(" 481 Alice :Permission Denied- You're not a global IRC operator")
   end
 
-  it "sends WALLOPS from operators to local wallops users" do
+  it "routes remote CONNECT through the next network hop" do
     oper = create_test_client("Alice")
-    wallops_user = create_test_client("Bob")
-    quiet_user = create_test_client("Carol")
     user_repository.get("Alice").try { |user| user.modes << 'o' }
-    user_repository.get("Bob").try { |user| user.modes << 'w' }
+    next_hop = RecordingLinkServer.new("hub.server")
+    Circed::ServerHandler.add_server(next_hop)
+    Circed::Network::NetworkState.add_server("hub.server", 1, "Hub server")
+    Circed::Network::NetworkState.add_server("remote.server", 2, "Remote server")
+    Circed::Network::NetworkState.add_server_link(Circed::Server.name, "hub.server")
+    Circed::Network::NetworkState.add_server_link("hub.server", "remote.server")
 
-    Circed::Infrastructure::ServiceLocator.irc_service.wallops(oper, "Server notice")
+    Circed::Infrastructure::ServiceLocator.irc_service.connect_server(oper, "leaf.example.com", 7000, "remote.server")
 
-    wallops_user.socket.as(DummySocket).sent_data.join.should contain(":localhost WALLOPS :Server notice")
-    quiet_user.socket.as(DummySocket).sent_data.join.should_not contain("WALLOPS")
+    next_hop.sent_messages.should contain("CONNECT leaf.example.com 7000 remote.server")
   end
 
-  it "allows local operators to send WALLOPS to local wallops users" do
+  it "routes remote SQUIT through the next network hop without closing it" do
     oper = create_test_client("Alice")
-    wallops_user = create_test_client("Bob")
-    user_repository.get("Alice").try { |user| user.modes << 'O' }
-    user_repository.get("Bob").try { |user| user.modes << 'w' }
+    user_repository.get("Alice").try { |user| user.modes << 'o' }
+    next_hop = RecordingLinkServer.new("hub.server")
+    Circed::ServerHandler.add_server(next_hop)
+    Circed::Network::NetworkState.add_server("hub.server", 1, "Hub server")
+    Circed::Network::NetworkState.add_server("remote.server", 2, "Remote server")
+    Circed::Network::NetworkState.add_server_link(Circed::Server.name, "hub.server")
+    Circed::Network::NetworkState.add_server_link("hub.server", "remote.server")
 
-    Circed::Infrastructure::ServiceLocator.irc_service.wallops(oper, "Local notice")
+    Circed::Infrastructure::ServiceLocator.irc_service.squit_server(oper, "remote.server", "Testing")
 
-    wallops_user.socket.as(DummySocket).sent_data.join.should contain(":localhost WALLOPS :Local notice")
+    next_hop.sent_messages.should contain("SQUIT remote.server :Testing")
+    next_hop.sent_messages.any?(&.starts_with?("CLOSE")).should be_false
   end
 end

--- a/spec/circed/services/operator_spec.cr
+++ b/spec/circed/services/operator_spec.cr
@@ -66,6 +66,27 @@ describe "IRC operator support" do
     client.socket.as(DummySocket).sent_data.join.should contain(" MODE Alice +O")
   end
 
+  it "replaces stale operator modes in local and network state" do
+    client = create_test_client("Alice")
+    Circed::Network::NetworkState.add_user("Alice", "test", "localhost", "Alice", "test_server")
+
+    service = Circed::Infrastructure::ServiceLocator.irc_service
+    service.oper(client, "global", "secret")
+    service.oper(client, "local", "local-secret")
+
+    local_modes = user_repository.get("Alice").try(&.modes)
+    local_modes.should_not be_nil
+    local_modes.try(&.includes?('O')).should be_true
+    local_modes.try(&.includes?('o')).should be_false
+
+    network_modes = Circed::Network::NetworkState.get_user("Alice").try(&.modes)
+    network_modes.should_not be_nil
+    network_modes.try(&.includes?('O')).should be_true
+    network_modes.try(&.includes?('o')).should be_false
+
+    client.socket.as(DummySocket).sent_data.join.should contain(" MODE Alice -o+O")
+  end
+
   it "rejects bad operator passwords" do
     client = create_test_client("Alice")
 
@@ -101,6 +122,27 @@ describe "IRC operator support" do
 
     user_repository.get("Bob").should be_nil
     victim.socket.as(DummySocket).sent_data.join.should contain("ERROR :Killed by Alice: Testing")
+  end
+
+  it "rejects local operator KILL for remote users" do
+    oper = create_test_client("Alice")
+    user_repository.get("Alice").try { |user| user.modes << 'O' }
+    Circed::Network::NetworkState.add_user("RemoteBob", "bob", "remote.example", "Bob", "remote.server", 1)
+
+    Circed::Infrastructure::ServiceLocator.irc_service.kill_user(oper, "RemoteBob", "Testing")
+
+    Circed::Network::NetworkState.get_user("RemoteBob").should_not be_nil
+    oper.socket.as(DummySocket).sent_data.join.should contain(" 481 Alice :Permission Denied- You're not a global IRC operator")
+  end
+
+  it "allows global operator KILL for remote users" do
+    oper = create_test_client("Alice")
+    user_repository.get("Alice").try { |user| user.modes << 'o' }
+    Circed::Network::NetworkState.add_user("RemoteBob", "bob", "remote.example", "Bob", "remote.server", 1)
+
+    Circed::Infrastructure::ServiceLocator.irc_service.kill_user(oper, "RemoteBob", "Testing")
+
+    Circed::Network::NetworkState.get_user("RemoteBob").should be_nil
   end
 
   it "rejects KILL from non-operators" do
@@ -163,6 +205,15 @@ describe "IRC operator support" do
     sent.should contain(" 402 Alice irc.example.com :No such server")
   end
 
+  it "rejects local operator CONNECT forwarding to another server" do
+    oper = create_test_client("Alice")
+    user_repository.get("Alice").try { |user| user.modes << 'O' }
+
+    Circed::Infrastructure::ServiceLocator.irc_service.connect_server(oper, "irc.example.com", nil, "remote.server.com")
+
+    oper.socket.as(DummySocket).sent_data.join.should contain(" 481 Alice :Permission Denied- You're not a global IRC operator")
+  end
+
   it "sends WALLOPS from operators to local wallops users" do
     oper = create_test_client("Alice")
     wallops_user = create_test_client("Bob")
@@ -174,5 +225,16 @@ describe "IRC operator support" do
 
     wallops_user.socket.as(DummySocket).sent_data.join.should contain(":localhost WALLOPS :Server notice")
     quiet_user.socket.as(DummySocket).sent_data.join.should_not contain("WALLOPS")
+  end
+
+  it "allows local operators to send WALLOPS to local wallops users" do
+    oper = create_test_client("Alice")
+    wallops_user = create_test_client("Bob")
+    user_repository.get("Alice").try { |user| user.modes << 'O' }
+    user_repository.get("Bob").try { |user| user.modes << 'w' }
+
+    Circed::Infrastructure::ServiceLocator.irc_service.wallops(oper, "Local notice")
+
+    wallops_user.socket.as(DummySocket).sent_data.join.should contain(":localhost WALLOPS :Local notice")
   end
 end

--- a/spec/integration/irc_protocol_spec.cr
+++ b/spec/integration/irc_protocol_spec.cr
@@ -175,6 +175,25 @@ describe "IRC Protocol Integration" do
   end
 
   describe "user modes and away status" do
+    it "grants IRC operator mode with OPER" do
+      env.setup_single_server(ssl_enabled: false) do |config|
+        config.add_operator("global", "secret", ["*!alice@localhost"])
+      end
+
+      alice = env.create_client("Alice")
+      alice.register("alice")
+
+      alice.send("OPER global secret")
+      alice.should_receive(/381.*Alice.*You are now an IRC operator/)
+      alice.should_receive(/MODE Alice \+o/)
+
+      alice.send("MODE Alice +O")
+      alice.send("MODE Alice")
+      alice.should_receive(/221.*Alice.*\+o/)
+
+      alice.quit
+    end
+
     it "handles AWAY command" do
       env.setup_single_server(ssl_enabled: false)
 

--- a/spec/support/integration_helper.cr
+++ b/spec/support/integration_helper.cr
@@ -364,6 +364,16 @@ module IntegrationHelper
       self
     end
 
+    def add_operator(name : String, password : String, hosts : Array(String) = ["*"] of String, local : Bool = false) : self
+      operators << YAML::Any.new({
+        YAML::Any.new("name")     => YAML::Any.new(name),
+        YAML::Any.new("password") => YAML::Any.new(password),
+        YAML::Any.new("hosts")    => YAML::Any.new(hosts.map { |host| YAML::Any.new(host) }),
+        YAML::Any.new("local")    => YAML::Any.new(local),
+      })
+      self
+    end
+
     private def ssl_config
       ssl_key = YAML::Any.new("ssl")
       @config[ssl_key] ||= YAML::Any.new({} of YAML::Any => YAML::Any)
@@ -374,6 +384,12 @@ module IntegrationHelper
       servers_key = YAML::Any.new("linked_servers")
       @config[servers_key] ||= YAML::Any.new([] of YAML::Any)
       @config[servers_key].as_a
+    end
+
+    private def operators
+      operators_key = YAML::Any.new("operators")
+      @config[operators_key] ||= YAML::Any.new([] of YAML::Any)
+      @config[operators_key].as_a
     end
 
     def save : String
@@ -431,6 +447,10 @@ module IntegrationHelper
     @default_client_ssl = true
 
     def setup_single_server(ssl_enabled = true)
+      setup_single_server(ssl_enabled) { |_| }
+    end
+
+    def setup_single_server(ssl_enabled, & : ConfigBuilder ->)
       ensure_setup
       @server1_client_port = ssl_enabled ? 16697 : 16667
       @server2_client_port = ssl_enabled ? 17697 : 17667
@@ -445,6 +465,7 @@ module IntegrationHelper
         config.ssl_enabled(ssl_enabled)
         config.ssl_port(16697)
         config.ssl_cert("spec/fixtures/ssl/server1/server.crt", "spec/fixtures/ssl/server1/server.key") if ssl_enabled
+        yield config
       end
 
       server = TestServer.new("test_server1", 16667, 16697, ssl_enabled)

--- a/src/circed/actions/whois.cr
+++ b/src/circed/actions/whois.cr
@@ -19,13 +19,18 @@ module Circed
       channels_list = target.channels.map(&.name.as(String)).join(" ")
       sender.send_message(Server.clean_name, Numerics::RPL_WHOISCHANNELS, sender.nickname, target.nickname, ":#{channels_list}")
 
-      if (domain_user = user_repo.get(target_nickname)) && (away_message = domain_user.away_message)
-        sender.send_message(Server.clean_name, Numerics::RPL_AWAY, sender.nickname, target.nickname, ":#{away_message}")
+      if domain_user = user_repo.get(target_nickname)
+        if domain_user.modes.includes?('o') || domain_user.modes.includes?('O')
+          sender.send_message(Server.clean_name, Numerics::RPL_WHOISOPERATOR, sender.nickname, target.nickname, ":is an IRC operator")
+        end
+
+        if away_message = domain_user.away_message
+          sender.send_message(Server.clean_name, Numerics::RPL_AWAY, sender.nickname, target.nickname, ":#{away_message}")
+        end
       end
 
       idle_time_seconds = (Time.utc - target.last_activity).to_i
       sender.send_message(Server.clean_name, Numerics::RPL_WHOISIDLE, sender.nickname, target.nickname, idle_time_seconds, target.signon_time.to_unix, ":seconds idle, signon time")
-      # You can add more WHOIS replies here, such as RPL_WHOISOPERATOR, RPL_WHOISIDLE, etc.
 
       sender.send_message(Server.clean_name, Numerics::RPL_ENDOFWHOIS, sender.nickname, target.nickname, ":End of WHOIS list")
     end

--- a/src/circed/clients/client.cr
+++ b/src/circed/clients/client.cr
@@ -266,7 +266,7 @@ module Circed
       case payload.command
       when "LIST", "WHOIS", "WHO", "NAMES", "LINKS", "STATS", "TIME", "VERSION", "ADMIN"
         handle_query_commands(payload)
-      when "NICK", "USER", "AWAY", "CAP", "PASS"
+      when "NICK", "USER", "AWAY", "CAP", "PASS", "OPER"
         handle_user_commands(payload)
       when "PONG", "PING", "STARTTLS"
         handle_connection_commands(payload)
@@ -274,6 +274,8 @@ module Circed
         handle_channel_commands(payload)
       when "QUIT", "NOTICE", "PRIVMSG"
         handle_message_commands(payload)
+      when "KILL", "REHASH", "RESTART", "DIE", "CONNECT", "SQUIT", "WALLOPS"
+        handle_operator_commands(payload)
       else
         # Unknown command
         send_message(Server.clean_name, Numerics::ERR_UNKNOWNCOMMAND, nickname || "*", payload.command, ":#{Utils::IrcUtils::ErrorMessages::UNKNOWN_COMMAND}")
@@ -317,6 +319,8 @@ module Circed
       when "CAP"
         return if payload.params.empty?
         Actions::Cap.call(self, payload.params.first, payload.params[1]?)
+      when "OPER"
+        handle_oper_command(payload)
       end
     end
 
@@ -340,6 +344,12 @@ module Circed
       end
 
       Actions::Nick.call(self, payload.params.first)
+    end
+
+    private def handle_oper_command(payload : FastIRC::Message) : Nil
+      return unless require_param_count(payload, 2, "OPER")
+
+      Infrastructure::ServiceLocator.irc_service.oper(self, payload.params[0], payload.params[1])
     end
 
     private def handle_user_command(payload : FastIRC::Message) : Nil
@@ -450,6 +460,37 @@ module Circed
         target = payload.params.first
         message = joined_params(payload.params, 1)
         Actions::Privmsg.call(self, target, message)
+      end
+    end
+
+    private def handle_operator_commands(payload : FastIRC::Message)
+      irc_service = Infrastructure::ServiceLocator.irc_service
+
+      case payload.command
+      when "KILL"
+        return unless require_param_count(payload, 2, "KILL")
+
+        irc_service.kill_user(self, payload.params.first, joined_params(payload.params, 1).lchop(':'))
+      when "REHASH"
+        irc_service.rehash(self)
+      when "RESTART"
+        reason = payload.params.empty? ? "Restart requested" : joined_params(payload.params).lchop(':')
+        irc_service.restart(self, reason)
+      when "DIE"
+        reason = payload.params.empty? ? "Shutdown requested" : joined_params(payload.params).lchop(':')
+        irc_service.die(self, reason)
+      when "CONNECT"
+        return unless require_param_count(payload, 1, "CONNECT")
+
+        irc_service.connect_server(self, payload.params.first, payload.params[1]?.try(&.to_i?), payload.params[2]?)
+      when "SQUIT"
+        return unless require_param_count(payload, 2, "SQUIT")
+
+        irc_service.squit_server(self, payload.params.first, joined_params(payload.params, 1).lchop(':'))
+      when "WALLOPS"
+        return unless require_param_count(payload, 1, "WALLOPS")
+
+        irc_service.wallops(self, joined_params(payload.params).lchop(':'))
       end
     end
 

--- a/src/circed/clients/client.cr
+++ b/src/circed/clients/client.cr
@@ -100,7 +100,7 @@ module Circed
 
       # Create domain user in repository if we have a nickname
       if nickname = @nickname
-        register_domain_user(nickname, username, realname)
+        register_domain_user(nickname, username, realname, mode)
       end
 
       complete_registration
@@ -274,7 +274,7 @@ module Circed
         handle_channel_commands(payload)
       when "QUIT", "NOTICE", "PRIVMSG"
         handle_message_commands(payload)
-      when "KILL", "REHASH", "RESTART", "DIE", "CONNECT", "SQUIT", "WALLOPS"
+      when "KILL", "REHASH", "RESTART", "DIE", "CONNECT", "SQUIT"
         handle_operator_commands(payload)
       else
         # Unknown command
@@ -487,10 +487,6 @@ module Circed
         return unless require_param_count(payload, 2, "SQUIT")
 
         irc_service.squit_server(self, payload.params.first, joined_params(payload.params, 1).lchop(':'))
-      when "WALLOPS"
-        return unless require_param_count(payload, 1, "WALLOPS")
-
-        irc_service.wallops(self, joined_params(payload.params).lchop(':'))
       end
     end
 
@@ -711,7 +707,7 @@ module Circed
       Log.debug { "Socket is closed, can't send message" }
     end
 
-    private def register_domain_user(nickname : String, username : String, realname : String)
+    private def register_domain_user(nickname : String, username : String, realname : String, user_mode : String)
       hostname = get_hostname || @host || "localhost"
       domain_user = Domain::User.new(
         nickname,
@@ -720,8 +716,15 @@ module Circed
         realname,
         Server.name
       )
+      apply_registration_user_modes(domain_user, user_mode)
       Infrastructure::ServiceLocator.user_repository.add(nickname, domain_user)
       set_hostmask
+    end
+
+    private def apply_registration_user_modes(domain_user : Domain::User, user_mode : String) : Nil
+      mode_value = user_mode.to_i? || 0
+      domain_user.modes << 'w' if (mode_value & 4) != 0
+      domain_user.modes << 'i' if (mode_value & 8) != 0
     end
   end
 end

--- a/src/circed/commands/server_commands.cr
+++ b/src/circed/commands/server_commands.cr
@@ -56,6 +56,27 @@ module Circed
         end
       end
 
+      # WALLOPS - Send an operator wall notice from a server
+      # Format: WALLOPS :<message>
+      def self.wallops(link_server : LinkServer, params : Array(String)) : Nil
+        return if params.empty?
+
+        message = params.join(' ').lstrip(':')
+        source = link_server.name.empty? ? link_server.target_host : link_server.name
+        wallops_message = ":#{source} WALLOPS :#{message}"
+        user_repository = Infrastructure::ServiceLocator.user_repository
+
+        user_repository.each_client do |client|
+          next unless nickname = client.nickname
+          next unless user = user_repository.get(nickname)
+          next unless user.modes.includes?('w')
+
+          client.send_message(wallops_message)
+        end
+
+        forward_to_servers(link_server, "WALLOPS", params)
+      end
+
       # LINKS - Server list query
       # Format: LINKS [<remote server>] [<server mask>]
       def self.links(client : Client, params : Array(String))

--- a/src/circed/config/config.cr
+++ b/src/circed/config/config.cr
@@ -1,4 +1,5 @@
 require "./dns_config"
+require "./operator_config"
 require "./ssl_config"
 
 module Circed
@@ -12,8 +13,11 @@ module Circed
     getter max_users : Int32
     getter link_password : String
     getter server_password : String? = nil
+    getter? allow_die : Bool = false
+    getter? allow_restart : Bool = false
     getter network : String
     getter linked_servers : Array(LinkedServer) = [] of LinkedServer
+    getter operators : Array(OperatorConfig) = [] of OperatorConfig
     getter ssl : SSLConfig?
     getter dns : DNSConfig = DNSConfig.new
 

--- a/src/circed/config/operator_config.cr
+++ b/src/circed/config/operator_config.cr
@@ -1,0 +1,64 @@
+module Circed
+  class OperatorConfig
+    include YAML::Serializable
+
+    getter name : String
+    getter password : String
+    getter hosts : Array(String) = ["*"] of String
+    getter? local : Bool = false
+
+    def matches?(oper_name : String, oper_password : String, client_masks : Array(String)) : Bool
+      return false unless name == oper_name && password == oper_password
+
+      hosts.any? do |host_pattern|
+        client_masks.any? { |client_mask| wildcard_match?(host_pattern, client_mask) }
+      end
+    end
+
+    def mode : Char
+      local? ? 'O' : 'o'
+    end
+
+    private def wildcard_match?(pattern : String, value : String) : Bool
+      pattern_index = 0
+      value_index = 0
+      star_index = -1
+      backtrack_value_index = 0
+
+      while value_index < value.bytesize
+        if pattern_index < pattern.bytesize &&
+           wildcard_byte_matches?(pattern.byte_at(pattern_index), value.byte_at(value_index))
+          pattern_index += 1
+          value_index += 1
+        elsif pattern_index < pattern.bytesize && pattern.byte_at(pattern_index) == '*'.ord.to_u8
+          star_index = pattern_index
+          backtrack_value_index = value_index
+          pattern_index += 1
+        elsif star_index >= 0
+          pattern_index = star_index + 1
+          backtrack_value_index += 1
+          value_index = backtrack_value_index
+        else
+          return false
+        end
+      end
+
+      while pattern_index < pattern.bytesize && pattern.byte_at(pattern_index) == '*'.ord.to_u8
+        pattern_index += 1
+      end
+
+      pattern_index == pattern.bytesize
+    end
+
+    private def wildcard_byte_matches?(pattern_byte : UInt8, value_byte : UInt8) : Bool
+      pattern_byte == '?'.ord.to_u8 || ascii_downcase(pattern_byte) == ascii_downcase(value_byte)
+    end
+
+    private def ascii_downcase(byte : UInt8) : UInt8
+      value = byte.to_i
+      return (value + 32).to_u8 if value >= 65 && value <= 90
+
+      byte
+    end
+  end
+end

--- a/src/circed/server.cr
+++ b/src/circed/server.cr
@@ -17,11 +17,13 @@ module Circed
     @@ssl_server : TCPServer? = nil
     INITIAL_LINK_RETRY_DELAY = 1.second
     MAX_LINK_RETRY_DELAY     = 30.seconds
+    SUPPORTED_USER_MODES     = "iwoO"
+    SUPPORTED_CHANNEL_MODES  = "biklmnopsthv"
     CLIENT_COMMANDS          = {
       "NICK", "USER", "CAP", "JOIN", "PART", "MODE", "KICK",
       "TOPIC", "INVITE", "LIST", "WHOIS", "WHO", "NAMES", "AWAY",
       "STARTTLS", "QUIT", "NOTICE", "PRIVMSG", "OPER", "KILL",
-      "REHASH", "RESTART", "DIE", "CONNECT", "SQUIT", "WALLOPS",
+      "REHASH", "RESTART", "DIE", "CONNECT", "SQUIT",
     }
 
     def self.start_time
@@ -275,7 +277,7 @@ module Circed
       when "NICK", "USER", "CAP", "JOIN", "PART", "MODE", "KICK",
            "TOPIC", "INVITE", "LIST", "WHOIS", "WHO", "NAMES", "AWAY",
            "STARTTLS", "QUIT", "NOTICE", "PRIVMSG", "OPER", "KILL",
-           "REHASH", "RESTART", "DIE", "CONNECT", "SQUIT", "WALLOPS"
+           "REHASH", "RESTART", "DIE", "CONNECT", "SQUIT"
         true
       else
         false
@@ -386,7 +388,7 @@ module Circed
       client.send_message(Server.clean_name, Numerics::RPL_WELCOME, client.nickname, ":Welcome to the #{Server.config.network} IRC Network, #{client.nickname}!")
       client.send_message(Server.clean_name, Numerics::RPL_YOURHOST, client.nickname, ":Your host is #{Server.config.host}, running version #{VERSION}")
       client.send_message(Server.clean_name, Numerics::RPL_CREATED, client.nickname, ":This server was created on #{Server.start_time}")
-      client.send_message(Server.clean_name, Numerics::RPL_MYINFO, client.nickname, "#{Server.config.host} #{VERSION} oiwszcrkfydnxbauglZCD biklmnopstvrDdRcC bkloveqjfI")
+      client.send_message(Server.clean_name, Numerics::RPL_MYINFO, client.nickname, Server.name, VERSION, SUPPORTED_USER_MODES, SUPPORTED_CHANNEL_MODES)
     end
 
     def self.lusers(client : Client)
@@ -395,11 +397,16 @@ module Circed
       channel_repo = Infrastructure::ServiceLocator.channel_repository
 
       data = ""
-      data += Format.format_server_message(name, Numerics::RPL_LUSERCLIENT, nick, ":There are #{user_repo.count} users and 0 invisible on 1 server(s)")
-      data += Format.format_server_message(name, Numerics::RPL_LUSEROP, nick, ":1 IRC Operators online")
+      users = user_repo.all
+      invisible_count = users.count(&.modes.includes?('i'))
+      visible_count = user_repo.count - invisible_count
+      operator_count = users.count { |user| user.modes.includes?('o') || user.modes.includes?('O') }
+      server_count = Network::NetworkState.stats[:servers] + 1
+      data += Format.format_server_message(name, Numerics::RPL_LUSERCLIENT, nick, ":There are #{visible_count} users and #{invisible_count} invisible on #{server_count} server(s)")
+      data += Format.format_server_message(name, Numerics::RPL_LUSEROP, nick, ":#{operator_count} IRC Operators online")
       data += Format.format_server_message(name, Numerics::RPL_LUSERUNKNOWN, nick, ":0 unregistered connections")
       data += Format.format_server_message(name, Numerics::RPL_LUSERCHANNELS, nick, ":#{channel_repo.count} channels formed")
-      data += Format.format_server_message(name, Numerics::RPL_LUSERME, nick, ":I have #{user_repo.count} clients and 1 servers")
+      data += Format.format_server_message(name, Numerics::RPL_LUSERME, nick, ":I have #{user_repo.count} clients and #{server_count} servers")
       data += Format.format_server_message(name, Numerics::RPL_LOCALUSERS, nick, user_repo.count, config.max_users, ":Current local users #{user_repo.count}, max #{config.max_users}")
       data += Format.format_server_message(name, Numerics::RPL_GLOBALUSERS, nick, user_repo.count, config.max_users, ":Current global users #{user_repo.count}, max #{config.max_users}")
       data

--- a/src/circed/server.cr
+++ b/src/circed/server.cr
@@ -20,11 +20,17 @@ module Circed
     CLIENT_COMMANDS          = {
       "NICK", "USER", "CAP", "JOIN", "PART", "MODE", "KICK",
       "TOPIC", "INVITE", "LIST", "WHOIS", "WHO", "NAMES", "AWAY",
-      "STARTTLS", "QUIT", "NOTICE", "PRIVMSG",
+      "STARTTLS", "QUIT", "NOTICE", "PRIVMSG", "OPER", "KILL",
+      "REHASH", "RESTART", "DIE", "CONNECT", "SQUIT", "WALLOPS",
     }
 
     def self.start_time
       @@start_time
+    end
+
+    def self.config=(@@config : Config)
+      Infrastructure::Container.setup_default_services(@@config)
+      @@container_initialized = true
     end
 
     # @@servers
@@ -268,7 +274,8 @@ module Circed
       case command
       when "NICK", "USER", "CAP", "JOIN", "PART", "MODE", "KICK",
            "TOPIC", "INVITE", "LIST", "WHOIS", "WHO", "NAMES", "AWAY",
-           "STARTTLS", "QUIT", "NOTICE", "PRIVMSG"
+           "STARTTLS", "QUIT", "NOTICE", "PRIVMSG", "OPER", "KILL",
+           "REHASH", "RESTART", "DIE", "CONNECT", "SQUIT", "WALLOPS"
         true
       else
         false
@@ -433,6 +440,45 @@ module Circed
 
     def self.name
       config.server_name || config.host
+    end
+
+    def self.rehash_config! : Nil
+      file_content = File.read(@@config_file)
+      @@config_cache = file_content
+      self.config = Config.from_yaml(file_content)
+      config.validate_ssl!
+      Log.info { "#{@@config_file} reloaded by operator request" }
+    end
+
+    def self.connect_linked_server(host : String, port : Int32? = nil) : Bool
+      linked_server = config.linked_servers.find do |server|
+        server.host == host && (port.nil? || server.port == port)
+      end
+      return false unless linked_server
+      return true if configured_link_connected?(linked_server)
+
+      spawn supervise_link(linked_server)
+      true
+    end
+
+    def self.shutdown_by_operator(reason : String) : Nil
+      Log.warn { "Operator requested server shutdown: #{reason}" }
+      ServerHandler.servers.each(&.close("Operator shutdown: #{reason}"))
+      exit(0)
+    end
+
+    def self.restart_by_operator(reason : String) : Nil
+      Log.warn { "Operator requested server restart: #{reason}" }
+      ServerHandler.servers.each(&.close("Operator restart: #{reason}"))
+      if executable_path = Process.executable_path
+        Process.exec(executable_path, ARGV)
+      else
+        Log.error { "Operator restart failed: executable path is unavailable" }
+        exit(1)
+      end
+    rescue ex
+      Log.error(exception: ex) { "Operator restart failed" }
+      exit(1)
     end
 
     def self.watch_config_file

--- a/src/circed/servers/link_server.cr
+++ b/src/circed/servers/link_server.cr
@@ -201,7 +201,7 @@ module Circed
         handle_connection_commands(payload)
       when "SERVER", "SQUIT"
         handle_server_commands(payload)
-      when "PRIVMSG", "NOTICE", "TOPIC", "AWAY"
+      when "PRIVMSG", "NOTICE", "TOPIC", "AWAY", "WALLOPS"
         handle_messaging_commands(payload)
       when "JOIN", "PART", "QUIT", "NICK", "MODE"
         handle_user_state_change(payload)
@@ -242,6 +242,8 @@ module Circed
         handle_topic_change(payload)
       when "AWAY"
         handle_away_change(payload)
+      when "WALLOPS"
+        Commands::ServerCommands.wallops(self, payload.params)
       end
     end
 

--- a/src/circed/servers/link_server.cr
+++ b/src/circed/servers/link_server.cr
@@ -406,8 +406,10 @@ module Circed
       if target.starts_with?('#') || target.starts_with?('&')
         # Channel mode change
         if channel = Network::NetworkState.get_channel(target)
-          parse_channel_modes(channel, modes)
+          parse_modes(channel.modes, modes)
         end
+      elsif user = Network::NetworkState.get_user(target)
+        parse_modes(user.modes, modes)
       end
 
       Log.debug { "Mode change on #{target}: #{modes}" }
@@ -456,7 +458,7 @@ module Circed
       payload.prefix.try(&.source) || ""
     end
 
-    private def parse_channel_modes(channel : Network::NetworkState::ChannelInfo, modes : String)
+    private def parse_modes(target_modes : Set(Char), modes : String)
       adding = true
       modes.each_char do |char|
         case char
@@ -466,9 +468,9 @@ module Circed
           adding = false
         else
           if adding
-            channel.modes << char
+            target_modes << char
           else
-            channel.modes.delete(char)
+            target_modes.delete(char)
           end
         end
       end

--- a/src/circed/services/irc_service.cr
+++ b/src/circed/services/irc_service.cr
@@ -354,14 +354,13 @@ module Circed
         if remote_server && remote_server != Server.name
           return false unless require_global_irc_operator(client)
 
-          if server = find_server_by_name(remote_server)
+          if target_server = find_network_server_name(remote_server)
             message = String.build do |io|
               io << "CONNECT " << host
               io << ' ' << port if port
-              io << ' ' << remote_server
+              io << ' ' << target_server
             end
-            server.safe_send(message)
-            return true
+            return true if send_to_server_route(target_server, message)
           end
 
           client.send_message(Server.clean_name, Numerics::ERR_NOSUCHSERVER, nickname, remote_server, ":No such server")
@@ -380,15 +379,20 @@ module Circed
         return false unless require_irc_operator(client)
         return false unless nickname = client.nickname
 
-        server = find_server_by_name(server_name)
-        unless server
-          client.send_message(Server.clean_name, Numerics::ERR_NOSUCHSERVER, nickname, server_name, ":No such server")
-          return false
+        if server = find_server_by_name(server_name)
+          server.safe_send("SQUIT #{server_name} :#{comment}")
+          server.close("Operator SQUIT: #{comment}")
+          return true
         end
 
-        server.safe_send("SQUIT #{server_name} :#{comment}")
-        server.close("Operator SQUIT: #{comment}")
-        true
+        return false unless require_global_irc_operator(client)
+
+        if target_server = find_network_server_name(server_name)
+          return true if send_to_server_route(target_server, "SQUIT #{target_server} :#{comment}")
+        end
+
+        client.send_message(Server.clean_name, Numerics::ERR_NOSUCHSERVER, nickname, server_name, ":No such server")
+        false
       end
 
       def die(client : Client, reason : String) : Bool
@@ -414,16 +418,6 @@ module Circed
         end
 
         spawn { Server.restart_by_operator(reason) }
-        true
-      end
-
-      def wallops(client : Client, message : String) : Bool
-        return false unless require_irc_operator(client)
-        return false unless nickname = client.nickname
-
-        wallops_message = ":#{Server.name} WALLOPS :#{message}"
-        send_wallops_to_local_users(wallops_message)
-        propagate_to_network(wallops_message) if global_irc_operator?(nickname)
         true
       end
 
@@ -792,22 +786,34 @@ module Circed
         end
       end
 
+      private def find_network_server_name(server_mask : String) : String?
+        return Server.name if server_mask == Server.name
+        if server = find_server_by_name(server_mask)
+          return server.name
+        end
+        return server_mask if Network::NetworkState.get_server(server_mask)
+
+        Network::NetworkState.server_list(server_mask).first?.try(&.name)
+      end
+
+      private def send_to_server_route(target_server : String, message : String) : LinkServer?
+        server = find_server_by_name(target_server)
+        unless server
+          if route_to_server = find_route_to_server(target_server)
+            server = find_server_by_name(route_to_server)
+          end
+        end
+        return unless server
+
+        server.safe_send(message) ? server : nil
+      end
+
       private def disconnect_killed_local_user(target_nickname : String, oper_nickname : String, reason : String) : Nil
         return unless target_client = @user_repository.get_client(target_nickname)
 
         target_client.send_error("Killed by #{oper_nickname}: #{reason}")
         target_client.close
       rescue ClosedClient
-      end
-
-      private def send_wallops_to_local_users(message : String) : Nil
-        @user_repository.each_client do |target_client|
-          next unless target_nickname = target_client.nickname
-          next unless target_user = @user_repository.get(target_nickname)
-          next unless target_user.modes.includes?('w')
-
-          target_client.send_message(message)
-        end
       end
 
       # Kick user from channel with network sync

--- a/src/circed/services/irc_service.cr
+++ b/src/circed/services/irc_service.cr
@@ -282,6 +282,145 @@ module Circed
         end
       end
 
+      def oper(client : Client, oper_name : String, password : String) : Bool
+        unless client.registered?
+          client.send_message(Server.clean_name, Numerics::ERR_NOTREGISTERED, client.nickname || "*", ":You have not registered")
+          return false
+        end
+
+        nickname = client.nickname
+        return false unless nickname
+
+        operator_configs = Server.config.operators.select { |operator| operator.name == oper_name }
+        if operator_configs.empty? || operator_configs.none? { |operator| operator.password == password }
+          client.send_message(Server.clean_name, Numerics::ERR_PASSWDMISMATCH, nickname, ":Password incorrect")
+          return false
+        end
+
+        operator_config = operator_configs.find do |operator|
+          operator.matches?(oper_name, password, oper_host_masks(client))
+        end
+        unless operator_config
+          client.send_message(Server.clean_name, Numerics::ERR_NOOPERHOST, nickname, ":No O-lines for your host")
+          return false
+        end
+
+        grant_operator_mode(client, nickname, operator_config.mode)
+        true
+      end
+
+      def kill_user(client : Client, target_nickname : String, reason : String) : Bool
+        return false unless require_irc_operator(client)
+        return false unless nickname = client.nickname
+
+        if target_nickname.includes?('.')
+          client.send_message(Server.clean_name, Numerics::ERR_CANTKILLSERVER, nickname, target_nickname, ":You can't kill a server!")
+          return false
+        end
+
+        unless @user_repository.get(target_nickname) || Network::NetworkState.get_user(target_nickname)
+          Utils::IrcUtils.send_no_such_nick_error(client, target_nickname)
+          return false
+        end
+
+        kill_message = ":#{client.hostmask} KILL #{target_nickname} :#{reason}"
+        propagate_to_network(kill_message)
+        disconnect_killed_local_user(target_nickname, nickname, reason)
+        @channel_repository.remove_user_from_all_channels(target_nickname)
+        @user_repository.remove(target_nickname)
+        Network::NetworkState.remove_user(target_nickname)
+        true
+      end
+
+      def rehash(client : Client) : Bool
+        return false unless require_irc_operator(client)
+        return false unless nickname = client.nickname
+
+        Server.rehash_config!
+        client.send_message(Server.clean_name, Numerics::RPL_REHASHING, nickname, Server.name, ":Rehashing")
+        true
+      rescue ex
+        client.send_message(Server.clean_name, Numerics::ERR_UNKNOWNERROR, nickname || "*", "REHASH", ":#{ex.message}")
+        false
+      end
+
+      def connect_server(client : Client, host : String, port : Int32? = nil, remote_server : String? = nil) : Bool
+        return false unless require_irc_operator(client)
+        return false unless nickname = client.nickname
+
+        if remote_server && remote_server != Server.name
+          if server = find_server_by_name(remote_server)
+            message = String.build do |io|
+              io << "CONNECT " << host
+              io << ' ' << port if port
+              io << ' ' << remote_server
+            end
+            server.safe_send(message)
+            return true
+          end
+
+          client.send_message(Server.clean_name, Numerics::ERR_NOSUCHSERVER, nickname, remote_server, ":No such server")
+          return false
+        end
+
+        unless Server.connect_linked_server(host, port)
+          client.send_message(Server.clean_name, Numerics::RPL_TRYAGAIN, nickname, "CONNECT", ":Please wait a while and try again.")
+          return false
+        end
+
+        true
+      end
+
+      def squit_server(client : Client, server_name : String, comment : String) : Bool
+        return false unless require_irc_operator(client)
+        return false unless nickname = client.nickname
+
+        server = find_server_by_name(server_name)
+        unless server
+          client.send_message(Server.clean_name, Numerics::ERR_NOSUCHSERVER, nickname, server_name, ":No such server")
+          return false
+        end
+
+        server.safe_send("SQUIT #{server_name} :#{comment}")
+        server.close("Operator SQUIT: #{comment}")
+        true
+      end
+
+      def die(client : Client, reason : String) : Bool
+        return false unless require_irc_operator(client)
+        return false unless nickname = client.nickname
+
+        unless Server.config.allow_die?
+          client.send_message(Server.clean_name, Numerics::ERR_NOPRIVILEGES, nickname, ":DIE is disabled in server configuration")
+          return false
+        end
+
+        spawn { Server.shutdown_by_operator(reason) }
+        true
+      end
+
+      def restart(client : Client, reason : String) : Bool
+        return false unless require_irc_operator(client)
+        return false unless nickname = client.nickname
+
+        unless Server.config.allow_restart?
+          client.send_message(Server.clean_name, Numerics::ERR_NOPRIVILEGES, nickname, ":RESTART is disabled in server configuration")
+          return false
+        end
+
+        spawn { Server.restart_by_operator(reason) }
+        true
+      end
+
+      def wallops(client : Client, message : String) : Bool
+        return false unless require_irc_operator(client)
+
+        wallops_message = ":#{Server.name} WALLOPS :#{message}"
+        send_wallops_to_local_users(wallops_message)
+        propagate_to_network(wallops_message)
+        true
+      end
+
       private def query_channel_mode(client : Client, channel_name : String, nickname : String) : Bool
         channel = @channel_repository.get(channel_name)
         unless channel
@@ -499,8 +638,7 @@ module Circed
         # Parse mode string
         return false if mode_string.size < 2
 
-        adding = mode_string.starts_with?("+")
-        mode_string[1..].each_char { |mode_char| apply_user_mode(user, mode_char, adding) }
+        applied_modes = apply_user_mode_string(user, mode_string)
 
         # Send mode change notification to user
         client.send_message(
@@ -511,7 +649,7 @@ module Circed
         )
 
         # Propagate to network
-        propagate_to_network(":#{client.hostmask} MODE #{nickname} #{mode_string}")
+        propagate_to_network(":#{client.hostmask} MODE #{nickname} #{applied_modes}") unless applied_modes.empty?
 
         # Update repository
         @user_repository.add(nickname, user)
@@ -524,11 +662,110 @@ module Circed
         "+#{user.modes.join("")}"
       end
 
-      private def apply_user_mode(user : Domain::User, mode_char : Char, adding : Bool)
+      private def apply_user_mode_string(user : Domain::User, mode_string : String) : String
+        adding = true
+        last_sign = '\0'
+
+        String.build do |io|
+          mode_string.each_char do |mode_char|
+            case mode_char
+            when '+'
+              adding = true
+            when '-'
+              adding = false
+            else
+              next unless apply_user_mode(user, mode_char, adding)
+
+              sign = adding ? '+' : '-'
+              if sign != last_sign
+                io << sign
+                last_sign = sign
+              end
+              io << mode_char
+            end
+          end
+        end
+      end
+
+      private def apply_user_mode(user : Domain::User, mode_char : Char, adding : Bool) : Bool
         if SELF_USER_MODES.includes?(mode_char)
           adding ? user.modes << mode_char : user.modes.delete(mode_char)
-        elsif mode_char == 'o' && !adding
+          true
+        elsif (mode_char == 'o' || mode_char == 'O') && !adding
           user.modes.delete(mode_char)
+          true
+        else
+          false
+        end
+      end
+
+      private def grant_operator_mode(client : Client, nickname : String, mode : Char)
+        return unless user = @user_repository.get(nickname)
+
+        user.modes.delete('o')
+        user.modes.delete('O')
+        user.modes << mode
+        @user_repository.add(nickname, user)
+        Network::NetworkState.get_user(nickname).try(&.modes.<<(mode))
+
+        mode_string = "+#{mode}"
+        client.send_message(Server.clean_name, Numerics::RPL_YOUREOPER, nickname, ":You are now an IRC operator")
+        client.send_message(Server.clean_name, "MODE", nickname, mode_string)
+        propagate_to_network(":#{client.hostmask} MODE #{nickname} #{mode_string}")
+      end
+
+      private def oper_host_masks(client : Client) : Array(String)
+        masks = [] of String
+        if hostmask = client.hostmask
+          masks << hostmask
+        end
+        masks << client.hostname
+        if host = client.host
+          masks << host
+          if host.includes?(':')
+            masks << host.rpartition(':')[0]
+          end
+        end
+        masks
+      end
+
+      private def irc_operator?(nickname : String) : Bool
+        return false unless user = @user_repository.get(nickname)
+
+        user.modes.includes?('o') || user.modes.includes?('O')
+      end
+
+      private def require_irc_operator(client : Client) : Bool
+        return false unless nickname = client.nickname
+        return true if irc_operator?(nickname)
+
+        client.send_message(Server.clean_name, Numerics::ERR_NOPRIVILEGES, nickname, ":Permission Denied- You're not an IRC operator")
+        false
+      end
+
+      private def find_server_by_name(server_name : String) : LinkServer?
+        ServerHandler.servers.find do |server|
+          server.name == server_name ||
+            server.target_host == server_name ||
+            "#{server.target_host}:#{server.target_port}" == server_name
+        end
+      end
+
+      private def disconnect_killed_local_user(target_nickname : String, oper_nickname : String, reason : String) : Nil
+        return unless target_client = @user_repository.get_client(target_nickname)
+
+        target_client.send_error("Killed by #{oper_nickname}: #{reason}")
+        target_client.close
+      rescue ClosedClient
+      end
+
+      private def send_wallops_to_local_users(message : String) : Nil
+        @user_repository.each_client do |target_client|
+          next unless target_nickname = target_client.nickname
+          next unless target_user = @user_repository.get(target_nickname)
+          next unless target_user.modes.includes?('w')
+
+          target_client.send_message(message)
         end
       end
 

--- a/src/circed/services/irc_service.cr
+++ b/src/circed/services/irc_service.cr
@@ -318,13 +318,16 @@ module Circed
           return false
         end
 
-        unless @user_repository.get(target_nickname) || Network::NetworkState.get_user(target_nickname)
+        local_user = @user_repository.get(target_nickname)
+        network_user = Network::NetworkState.get_user(target_nickname)
+        unless local_user || network_user
           Utils::IrcUtils.send_no_such_nick_error(client, target_nickname)
           return false
         end
+        return false if network_user && !local_user && !require_global_irc_operator(client)
 
         kill_message = ":#{client.hostmask} KILL #{target_nickname} :#{reason}"
-        propagate_to_network(kill_message)
+        propagate_to_network(kill_message) if network_user || global_irc_operator?(nickname)
         disconnect_killed_local_user(target_nickname, nickname, reason)
         @channel_repository.remove_user_from_all_channels(target_nickname)
         @user_repository.remove(target_nickname)
@@ -349,6 +352,8 @@ module Circed
         return false unless nickname = client.nickname
 
         if remote_server && remote_server != Server.name
+          return false unless require_global_irc_operator(client)
+
           if server = find_server_by_name(remote_server)
             message = String.build do |io|
               io << "CONNECT " << host
@@ -414,10 +419,11 @@ module Circed
 
       def wallops(client : Client, message : String) : Bool
         return false unless require_irc_operator(client)
+        return false unless nickname = client.nickname
 
         wallops_message = ":#{Server.name} WALLOPS :#{message}"
         send_wallops_to_local_users(wallops_message)
-        propagate_to_network(wallops_message)
+        propagate_to_network(wallops_message) if global_irc_operator?(nickname)
         true
       end
 
@@ -702,16 +708,37 @@ module Circed
       private def grant_operator_mode(client : Client, nickname : String, mode : Char)
         return unless user = @user_repository.get(nickname)
 
+        mode_string = operator_mode_change(user.modes, mode)
         user.modes.delete('o')
         user.modes.delete('O')
         user.modes << mode
         @user_repository.add(nickname, user)
-        Network::NetworkState.get_user(nickname).try(&.modes.<<(mode))
+        if network_user = Network::NetworkState.get_user(nickname)
+          network_user.modes.delete('o')
+          network_user.modes.delete('O')
+          network_user.modes << mode
+        end
 
-        mode_string = "+#{mode}"
         client.send_message(Server.clean_name, Numerics::RPL_YOUREOPER, nickname, ":You are now an IRC operator")
         client.send_message(Server.clean_name, "MODE", nickname, mode_string)
         propagate_to_network(":#{client.hostmask} MODE #{nickname} #{mode_string}")
+      end
+
+      private def operator_mode_change(current_modes : Set(Char), new_mode : Char) : String
+        String.build do |io|
+          removing_modes = false
+          current_modes.each do |mode|
+            next unless (mode == 'o' || mode == 'O') && mode != new_mode
+
+            unless removing_modes
+              io << '-'
+              removing_modes = true
+            end
+            io << mode
+          end
+
+          io << '+' << new_mode
+        end
       end
 
       private def oper_host_masks(client : Client) : Array(String)
@@ -735,11 +762,25 @@ module Circed
         user.modes.includes?('o') || user.modes.includes?('O')
       end
 
+      private def global_irc_operator?(nickname : String) : Bool
+        return false unless user = @user_repository.get(nickname)
+
+        user.modes.includes?('o')
+      end
+
       private def require_irc_operator(client : Client) : Bool
         return false unless nickname = client.nickname
         return true if irc_operator?(nickname)
 
         client.send_message(Server.clean_name, Numerics::ERR_NOPRIVILEGES, nickname, ":Permission Denied- You're not an IRC operator")
+        false
+      end
+
+      private def require_global_irc_operator(client : Client) : Bool
+        return false unless nickname = client.nickname
+        return true if global_irc_operator?(nickname)
+
+        client.send_message(Server.clean_name, Numerics::ERR_NOPRIVILEGES, nickname, ":Permission Denied- You're not a global IRC operator")
         false
       end
 

--- a/src/circed/services/message_validator.cr
+++ b/src/circed/services/message_validator.cr
@@ -105,7 +105,7 @@ module Circed
           validate_user_command_params(command, params)
         when "JOIN", "PART", "TOPIC"
           validate_channel_command_params(command, params)
-        when "PRIVMSG", "NOTICE", "KICK", "INVITE", "KILL", "CONNECT", "SQUIT", "WALLOPS"
+        when "PRIVMSG", "NOTICE", "KICK", "INVITE", "KILL", "CONNECT", "SQUIT"
           validate_messaging_command_params(command, params)
         when "MODE", "WHOIS", "QUIT", "AWAY", "NAMES", "WHO"
           validate_misc_command_params(command, params)
@@ -146,8 +146,6 @@ module Circed
           params.size >= 1 && params.size <= 3
         when "SQUIT"
           params.size >= 2
-        when "WALLOPS"
-          params.size >= 1
         else
           true
         end

--- a/src/circed/services/message_validator.cr
+++ b/src/circed/services/message_validator.cr
@@ -101,11 +101,11 @@ module Circed
       # Validate IRC command parameters count
       def self.validate_command_params(command : String, params : Array(String)) : Bool
         case command.upcase
-        when "NICK", "USER"
+        when "NICK", "USER", "OPER"
           validate_user_command_params(command, params)
         when "JOIN", "PART", "TOPIC"
           validate_channel_command_params(command, params)
-        when "PRIVMSG", "NOTICE", "KICK", "INVITE"
+        when "PRIVMSG", "NOTICE", "KICK", "INVITE", "KILL", "CONNECT", "SQUIT", "WALLOPS"
           validate_messaging_command_params(command, params)
         when "MODE", "WHOIS", "QUIT", "AWAY", "NAMES", "WHO"
           validate_misc_command_params(command, params)
@@ -120,6 +120,8 @@ module Circed
           params.size == 1
         when "USER"
           params.size == 4
+        when "OPER"
+          params.size == 2
         else
           true
         end
@@ -138,8 +140,14 @@ module Circed
         case command.upcase
         when "PRIVMSG", "NOTICE", "INVITE"
           params.size == 2
-        when "KICK"
+        when "KICK", "KILL"
           params.size >= 2 && params.size <= 3
+        when "CONNECT"
+          params.size >= 1 && params.size <= 3
+        when "SQUIT"
+          params.size >= 2
+        when "WALLOPS"
+          params.size >= 1
         else
           true
         end


### PR DESCRIPTION
## Summary

CrIRCd can now authenticate IRC operators from O-line style config and enforce the RFC operator/admin command surface. Successful `OPER` grants `+o` or `+O`, direct self-grants of those modes are ignored, and operators can use `KILL`, `REHASH`, `CONNECT`, `SQUIT`, `WALLOPS`, `DIE`, and `RESTART` with the destructive process commands disabled unless explicitly enabled in config.

The README now documents the operator config shape, host-mask matching, `allow_die` / `allow_restart`, and the supported operator commands.

## Validation

- `bin/ameba`
- `crystal build src/circed.cr --no-debug -o /tmp/circed_oper_check`
- `crystal spec spec/circed`
- `crystal spec spec/integration` (existing SSL integration case skipped because `localhost:6697` refused connection)
