### PR TITLE
stabilize cross-server messaging tests

### DIFF
--- a/spec/integration/message_routing_spec.cr
+++ b/spec/integration/message_routing_spec.cr
@@ -85,6 +85,7 @@ describe "Message Routing Integration" do
 
       alice.register
       bob.register
+      alice.wait_until_online("Bob")
 
       # Alice on server 1 messages Bob on server 2
       alice.privmsg("Bob", "Cross-server private message")
@@ -208,6 +209,7 @@ describe "Message Routing Integration" do
 
       alice.register
       bob.register
+      alice.wait_until_online("Bob")
 
       # CTCP PING request across servers
       alice.send("PRIVMSG Bob :\x01PING 1234567890\x01")

--- a/spec/support/integration_helper.cr
+++ b/spec/support/integration_helper.cr
@@ -189,6 +189,19 @@ module IntegrationHelper
       self
     end
 
+    def wait_until_online(nickname : String, timeout : Time::Span = 2.seconds)
+      deadline = Time.monotonic + timeout
+      pattern = / 303 \S+ :?.*\b#{Regex.escape(nickname)}\b/
+
+      until Time.monotonic >= deadline
+        send("ISON #{nickname}")
+        return self if wait_for_response(pattern, 0.2.seconds)
+      end
+
+      expect_response(pattern, 0.seconds)
+      self
+    end
+
     def wait_for_response(pattern : Regex, timeout : Time::Span = 5.seconds) : String?
       deadline = Time.monotonic + timeout
 


### PR DESCRIPTION
## Summary

Cross-server private-message and CTCP integration tests no longer send before a remote nickname has propagated between linked servers. They now poll the server's observable `ISON` state instead of relying on timing, preserving the intentionally asynchronous server-link behavior while removing the CI race.

## Validation

- 324 unit specs passed
- 84 integration specs passed with randomized ordering
- Both affected cross-server examples passed together with randomized ordering
- Ameba and Crystal formatting checks passed